### PR TITLE
Bump minimum node version in build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
 
       - name: Dependencies
         run: make install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+[0.5.2] - 2022-08-09
+- Bump minimum node version from 12.x to 14.x
+
 ### [0.5.1] - 2022-05-05
 
 - Ignore .vercel folder during deployment

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,7 @@ export const build: BuildV3 = async ({
       ...runtimeFiles
     },
     handler: 'launcher.launcher',
-    runtime: 'nodejs12.x',
+    runtime: 'nodejs14.x',
     environment: {
       NOW_ENTRYPOINT: entrypoint,
       NOW_PHP_DEV: meta.isDev ? '1' : '0'


### PR DESCRIPTION
Vercel is now actively blocking builds / deployments that are still using the 12.x runtime, the main action runs but if there is anything else that possible to test please let me know.