### PR TITLE
fork: add custom env docroot for php built-in server

### DIFF
--- a/src/launchers/builtin.ts
+++ b/src/launchers/builtin.ts
@@ -9,13 +9,14 @@ import {
   transformToAwsResponse,
   isDev
 } from './helpers';
+import { join as pathJoin } from 'path';
 
 let server: ChildProcess;
 
 async function startServer(entrypoint: string): Promise<ChildProcess> {
   // Resolve document root and router
   const router = entrypoint;
-  const docroot = getUserDir();
+  const docroot = pathJoin(getUserDir(), process.env.VERCEL_LARAVEL_DOCROOT ?? '');
 
   console.log(`🐘 Spawning: PHP Built-In Server at ${docroot} (document root) and ${router} (router)`);
 

--- a/src/launchers/builtin.ts
+++ b/src/launchers/builtin.ts
@@ -16,7 +16,7 @@ let server: ChildProcess;
 async function startServer(entrypoint: string): Promise<ChildProcess> {
   // Resolve document root and router
   const router = entrypoint;
-  const docroot = pathJoin(getUserDir(), process.env.VERCEL_LARAVEL_DOCROOT ?? '');
+  const docroot = pathJoin(getUserDir(), process.env.VERCEL_PHP_DOCROOT ?? '');
 
   console.log(`🐘 Spawning: PHP Built-In Server at ${docroot} (document root) and ${router} (router)`);
 


### PR DESCRIPTION
Hi,

A day ago, I attempted to deploy a Laravel 10.x application on Vercel using your runtime, and I encountered issues with the functionality of the api/ routes in Laravel. Despite PHP not being my primary language (yet!), I delved into the problem for about 2 hours. It turned out that there was an error related to routing and the root folder. The solution was to align the docroot of PHP in the built-in server with the location of api/index.php. This adjustment allowed my api/ routes to function correctly.

In my effort to contribute to this fantastic package, I've created a pull request that introduces the ability to choose the docroot directory through a previously defined environment variable. This modification proved immensely helpful for me. As a result, the latest versions of Laravel now deploy smoothly.