### PR TITLE
fix: autodetect nodejs runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vercel-php",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vercel-php",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@libphp/amazon-linux-2-v83": "latest"

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,8 @@ import {
   download,
   Lambda,
   BuildV3,
-  PrepareCache
+  PrepareCache,
+  getNodeVersion
 } from '@vercel/build-utils';
 import {
   getPhpFiles,
@@ -113,6 +114,7 @@ export const build: BuildV3 = async ({
   }
 
   console.log('🐘 Creating lambda');
+  const nodeVersion = await getNodeVersion(workPath);
 
   const lambda = new Lambda({
     files: {
@@ -123,7 +125,7 @@ export const build: BuildV3 = async ({
       ...runtimeFiles
     },
     handler: 'launcher.launcher',
-    runtime: 'nodejs18.x',
+    runtime: nodeVersion.runtime,
     environment: {
       NOW_ENTRYPOINT: entrypoint,
       NOW_PHP_DEV: meta.isDev ? '1' : '0'


### PR DESCRIPTION
Closes https://github.com/vercel-community/php/issues/531
Closes https://github.com/vercel-community/php/issues/534
Relates to https://github.com/vercel-community/php/issues/504#issuecomment-2024215402

Vercel recently shipped [Node.js 20 GA](https://vercel.com/changelog/node-js-v20-lts-is-now-generally-available), which means the default Node.js version for new projects is Node.js 20.

However, this project hardcodes the runtime to be `nodejs18.x`, instead of auto-detecting the user-defined Node.js version to set the correct runtime.