### PR TITLE
Update README.md (deploy button fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ vercel
 
 Are you ready to deploy your first PHP project to Vercel? Click & Go!
 
-<a href="https://vercel.com/new/project?template=https://github.com/juicyfx/vercel-examples/tree/master/php"><img src="https://vercel.com/button"></a>
+<a href="https://vercel.com/new/clone?repository-url=https://github.com/juicyfx/vercel-examples/tree/master/php"><img src="https://vercel.com/button"></a>
 
 ## 🤗 Features
 


### PR DESCRIPTION
An old deploy button URL `https://vercel.com/new/project?template=https://github.com/juicyfx/vercel-examples/tree/master/php` has a `project` in path and `template` as a GET parameter, which aren't longer supported. The new correct format is `https://vercel.com/new/clone?repository-url=https://github.com/juicyfx/vercel-examples/tree/master/php` (double check the repository-url).