### PR TITLE
fix: exclude build artifacts to prevent 250MB limit errors in monorepos

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,9 +91,20 @@ export const build: BuildV3 = async ({
             ? config.excludeFiles
             : [config.excludeFiles]
           : [
+              // Dependencies
               'node_modules/**',
+              // Build outputs and caches
+              '.next/**',
+              '.turbo/**',
+              'dist/**',
+              '.cache/**',
+              '.nuxt/**',
+              '.svelte-kit/**',
+              '.output/**',
+              // Legacy Vercel files
               'now.json',
               '.nowignore',
+              // Vercel configuration
               'vercel.json',
               '.vercelignore',
             ]),


### PR DESCRIPTION
## Problem

When using `vercel-php` in modern monorepo setups (Turbo, Next.js, Nuxt, SvelteKit, etc.), deployments fail with:

> **Error: A Serverless Function has exceeded the unzipped maximum size of 250 MB**

### Root Cause

The PHP runtime bundles **all files from `workPath`** into each serverless function, excluding only:
- `node_modules/**`
- Vercel config files

Modern frameworks generate large build artifacts (`.next/`, `.turbo/`, etc.) that weren't common when this runtime was created. These directories get included in **every PHP function**, causing massive bundle sizes.

### Real-World Example

In a Turbo monorepo with Next.js:
- `.next/` folder: **662 MB** (mostly webpack cache)
- Result: Each PHP function tries to bundle this → deployment fails
- After fix: PHP functions are **~38 MB** → deployment succeeds ✅

## Solution

Update the default `excludeFiles` list to exclude common modern build directories:

- `.next/**` - Next.js build output
- `.turbo/**` - Turbo cache  
- `dist/**` - Common build output
- `.cache/**` - General build caches
- `.nuxt/**` - Nuxt.js build
- `.svelte-kit/**` - SvelteKit build
- `.output/**` - Nitro/Nuxt output




### Additional Context
This issue became prominent with the rise of:
- Monorepo tooling (Turbo, Nx, Rush)
- Aggressive build caching strategies

