### PR TITLE
fix: update getNodeVersion to getRuntimeNodeVersion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {
   Lambda,
   BuildV3,
   PrepareCache,
-  getNodeVersion
+  getRuntimeNodeVersion
 } from '@vercel/build-utils';
 import {
   getPhpFiles,
@@ -114,7 +114,7 @@ export const build: BuildV3 = async ({
   }
 
   console.log('🐘 Creating lambda');
-  const nodeVersion = await getNodeVersion(workPath);
+  const nodeVersion = await getRuntimeNodeVersion(workPath);
 
   const lambda = new Lambda({
     files: {


### PR DESCRIPTION
## Summary

In `@vercel/build-utils`, the function `getNodeVersion` has been renamed to `getRuntimeNodeVersion` (vercel/vercel#14600), which causes the build to fail.

This PR updates the import and function call to use the new function name.

Fixes #594

## Error

Error: (0 , build_utils_1.getNodeVersion) is not a function

## Changes

- Updated import: `getNodeVersion` → `getRuntimeNodeVersion` (line 10)
- Updated function call: `getNodeVersion(workPath)` → `getRuntimeNodeVersion(workPath)` (line 117)

## Related

- vercel/vercel#14600